### PR TITLE
T182889: Fix display of last annotation in document listing

### DIFF
--- a/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
+++ b/siga-ex/src/main/java/br/gov/jfrj/siga/ex/bl/ExBL.java
@@ -3274,7 +3274,7 @@ public class ExBL extends CpBL {
 
     public static String anotacaoConfidencial(ExMobil mob, DpPessoa titular, DpLotacao lotaTitular) {
         if (mob.isGeral())
-            return "";
+            mob = mob.getDoc().getUltimoVolume();
 
         if (mostraDescricaoConfidencial(mob.doc(), titular, lotaTitular))
             return "CONFIDENCIAL";


### PR DESCRIPTION
In the function for obtaining confidential notes, we had a rule that returned empty when the list's mobil was the general one.

It turns out that the note movements are inserted in the last volume mobil, and when the process is archived, the system records the archiving movement in the general mobil. When listing the archived document mobil, we will be displaying the general mobil, since the archiving movement is there.

An adjustment was made to search for the last volume of the base document in order to find the last note present in it.